### PR TITLE
Fix normalization bug in QualiaField initialization

### DIFF
--- a/astra/core/field.py
+++ b/astra/core/field.py
@@ -171,8 +171,15 @@ class QualiaField:
             except (AttributeError, KeyError) as e:
                 print(f"Warning: Could not add {planet_key}: {e}")
         
-        # Normalize to nice range
-        self.state = self.state / np.max(np.abs(self.state)) * 2 - 1
+        # Normalize to [-1, 1] if the field has any variation. The previous
+        # implementation attempted to shift the range using ``* 2 - 1``, which
+        # actually produced values in ``[-3, 1]`` and triggered a division by
+        # zero when the field was entirely flat. We instead scale by the maximum
+        # absolute value only when it is non-zero, leaving a zero field
+        # unchanged.
+        max_val = np.max(np.abs(self.state))
+        if max_val > 0:
+            self.state = self.state / max_val
     
     def get_state(self) -> np.ndarray:
         """


### PR DESCRIPTION
## Summary
- guard normalization of field initialization against zero division and incorrect range

## Testing
- `pytest tests/test_core.py tests/test_evolution.py tests/test_narrative.py tests/test_topology.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e5f728758832ab06c49eccc528920