### PR TITLE
Add simple birth input page

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ python -m http.server 8000
 
 The web interface provides a simple way to interact with ASTRA without needing to install all the dependencies or run Python code directly.
 
+### Simple Input Page
+
+If the main interface is too feature-rich or requires external API keys, a minimal fallback is available at [`docs/simple.html`](docs/simple.html).
+It offers a basic form with name, birth date, time, and city fields using the built-in city database and displays a lightweight analysis without any additional setup.
+
 ## Modules 🧩
 
 ### `/core` ✅

--- a/docs/simple.html
+++ b/docs/simple.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ASTRA – Simple Input</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>ASTRA – Simple Input</h1>
+  <form id="birth-form">
+    <label>Name:
+      <input type="text" id="name" required>
+    </label>
+    <label>Birth Date:
+      <input type="date" id="date" required>
+    </label>
+    <label>Birth Time:
+      <input type="time" id="time" required>
+    </label>
+    <label>Birth Place:
+      <input type="text" id="city" list="city-options" placeholder="City, Country" required>
+      <datalist id="city-options"></datalist>
+    </label>
+    <button type="submit">Generate Analysis</button>
+  </form>
+  <pre id="analysis"></pre>
+  <script src="simple.js"></script>
+</body>
+</html>

--- a/docs/simple.js
+++ b/docs/simple.js
@@ -1,0 +1,65 @@
+// Simple input handling for ASTRA
+async function searchCities(query) {
+  const response = await fetch(`/city_search?query=${encodeURIComponent(query)}`);
+  if (!response.ok) return [];
+  return await response.json();
+}
+
+function getZodiacSign(month, day) {
+  const signs = ['Aries','Taurus','Gemini','Cancer','Leo','Virgo','Libra','Scorpio','Sagittarius','Capricorn','Aquarius','Pisces'];
+  if ((month === 3 && day >= 21) || (month === 4 && day <= 19)) return signs[0];
+  if ((month === 4 && day >= 20) || (month === 5 && day <= 20)) return signs[1];
+  if ((month === 5 && day >= 21) || (month === 6 && day <= 20)) return signs[2];
+  if ((month === 6 && day >= 21) || (month === 7 && day <= 22)) return signs[3];
+  if ((month === 7 && day >= 23) || (month === 8 && day <= 22)) return signs[4];
+  if ((month === 8 && day >= 23) || (month === 9 && day <= 22)) return signs[5];
+  if ((month === 9 && day >= 23) || (month === 10 && day <= 22)) return signs[6];
+  if ((month === 10 && day >= 23) || (month === 11 && day <= 21)) return signs[7];
+  if ((month === 11 && day >= 22) || (month === 12 && day <= 21)) return signs[8];
+  if ((month === 12 && day >= 22) || (month === 1 && day <= 19)) return signs[9];
+  if ((month === 1 && day >= 20) || (month === 2 && day <= 18)) return signs[10];
+  return signs[11];
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const cityInput = document.getElementById('city');
+  const datalist = document.getElementById('city-options');
+
+  cityInput.addEventListener('input', async () => {
+    const q = cityInput.value.trim();
+    if (q.length < 2) return;
+    const cities = await searchCities(q);
+    datalist.innerHTML = '';
+    cities.forEach(c => {
+      const option = document.createElement('option');
+      option.value = `${c.city}, ${c.country}`;
+      option.dataset.lat = c.lat;
+      option.dataset.lng = c.lng;
+      datalist.appendChild(option);
+    });
+  });
+
+  document.getElementById('birth-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const [cityName, country = ''] = cityInput.value.split(',').map(s => s.trim());
+    let lat = '', lng = '';
+    if (cityName && country) {
+      try {
+        const resp = await fetch(`/city_lookup?city=${encodeURIComponent(cityName)}&country=${encodeURIComponent(country)}`);
+        const data = await resp.json();
+        lat = data.lat || '';
+        lng = data.lng || '';
+      } catch (err) {
+        console.error('Lookup failed', err);
+      }
+    }
+    const date = document.getElementById('date').value;
+    const [year, month, day] = date.split('-').map(Number);
+    const analysisText = `Name: ${document.getElementById('name').value}\n` +
+      `Birth Date: ${date}\n` +
+      `Birth Time: ${document.getElementById('time').value}\n` +
+      `Location: ${cityName}, ${country} (${lat}, ${lng})\n` +
+      `Sun Sign: ${getZodiacSign(month, day)}`;
+    document.getElementById('analysis').textContent = analysisText;
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal HTML page for entering name, birth date, time and city using local city search
- include JavaScript helper for city autocomplete and basic sun-sign analysis
- document the new fallback interface in README

## Testing
- `pytest tests/test_core.py tests/test_evolution.py tests/test_simple.py tests/test_diagnostic.py tests/test_narrative.py tests/test_topology.py` *(fails: fixture 'name' not found in tests/test_simple.py and tests/test_diagnostic.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1363bf34832a8a83ba08ba262d09