### PR TITLE
Fix test imports and skip archived suites

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = archive

--- a/tests/archive/test_core_ascii.py
+++ b/tests/archive/test_core_ascii.py
@@ -12,8 +12,15 @@ matplotlib.use('Agg')  # Use non-interactive backend
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 
-# Make sure we can import from the astra package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Ensure the project root is on the Python path so the ``astra`` package can
+# be imported when this file is executed directly.  ``__file__`` points to
+# ``tests/archive/test_core_ascii.py`` so we need to traverse three directories
+# up to reach the repository root.
+PROJECT_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
 
 # Import ASTRA core modules
 try:

--- a/tests/test_diagnostic.py
+++ b/tests/test_diagnostic.py
@@ -28,11 +28,11 @@ def section_header(title):
     print(title)
     print("-" * 60)
 
-def test_component(name, test_func):
-    """Run a test with proper error handling"""
+def run_component(name, test_func):
+    """Run a test section with proper error handling"""
     section_header(f"Testing {name}")
     component_start = time.time()
-    
+
     success = False
     try:
         result = test_func()
@@ -41,10 +41,10 @@ def test_component(name, test_func):
     except Exception as e:
         print(f"✗ ERROR: {type(e).__name__}: {str(e)}")
         traceback.print_exc(limit=2)
-    
+
     duration = time.time() - component_start
     print(f"Duration: {duration:.2f} seconds")
-    
+
     return success
 
 def test_imports():
@@ -409,7 +409,7 @@ def main():
     
     results = []
     for name, func in tests:
-        success = test_component(name, func)
+        success = run_component(name, func)
         results.append((name, success))
     
     # Print summary

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -12,11 +12,20 @@ import traceback
 import numpy as np
 import matplotlib.pyplot as plt
 
+# When this file is executed directly (``python tests/test_simple.py``) the
+# working directory becomes the ``tests`` folder, meaning the project root is
+# not automatically on ``sys.path``.  Add the parent directory so that the
+# ``astra`` package can be imported without requiring installation.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
 # Make sure output directory exists
 os.makedirs("output/simple_test", exist_ok=True)
 
-# Error handler
-def test_section(name, test_func):
+# Error handler helper used when running this file directly.  The name does not
+# start with ``test_`` so that pytest does not try to treat it as a test.
+def run_section(name, test_func):
     """Run a test section with proper error handling"""
     print(f"\n{'='*60}")
     print(f"Testing {name}...")
@@ -186,7 +195,7 @@ def main():
     
     results = []
     for name, func in tests:
-        success = test_section(name, func)
+        success = run_section(name, func)
         results.append((name, success))
     
     # Print summary


### PR DESCRIPTION
## Summary
- ensure archived ASCII core test adds project root to `sys.path`
- add project root to `tests/test_simple.py` and avoid accidental PyTest collection
- rename diagnostic helper to `run_component`
- ignore `tests/archive` during discovery via `pytest.ini`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1874ea98832a84a2d0a1f0c741d0