### PR TITLE
Fix GitHub Pages deployment by updating artifact action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Create config file with API key
         run: |
@@ -31,13 +31,13 @@ jobs:
           echo "Config file created with API key"
       
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'docs'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update pages workflow to use upload-pages-artifact v4 and other latest GitHub actions

## Testing
- `pytest -q >/tmp/pytest.log && tail -n 2 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa1b74ddec832a8ed0e7f3ce0a5520