### PR TITLE
Add UX text suite (docs) and make narrative tests headless/faster

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,11 @@
             <div id="input" class="tab-pane active">
                 <h2>Enter Your Birth Information</h2>
                 <p class="introduction-text">ASTRA transforms your birth data into a quantum consciousness topology map. <span class="info-tooltip" data-tooltip="Your birth information serves as initial conditions for the field equations that generate your unique consciousness topology.">How does it work?</span></p>
+                <div class="ux-output" id="ux-input-output">
+                    <h3>UX Test Output: Input Module</h3>
+                    <p class="ux-output-hint">Live validation and input updates will appear here.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <form id="birth-data-form" onsubmit="return false;">
                     <div class="form-group">
                         <label for="name">Name:</label>
@@ -266,6 +271,11 @@
             <div id="visualization" class="tab-pane">
                 <h2>QualiaField Visualization</h2>
                 <p>Your QualiaField represents the topological structure of your conscious experience as modeled by ASTRA. <span class="info-tooltip" data-tooltip="ASTRA visualizes your consciousness as an evolving field with unique topological features that shape your experience of reality.">What is a QualiaField?</span></p>
+                <div class="ux-output" id="ux-visualization-output">
+                    <h3>UX Test Output: Visualization Module</h3>
+                    <p class="ux-output-hint">Visualization controls update this feed.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <div class="explanation-card">
                     <div class="card-header">
                         <i class="fas fa-info-circle"></i>
@@ -393,6 +403,11 @@
             <div id="echo-viewer" class="tab-pane">
                 <h2>Narrative Echo Viewer</h2>
                 <p class="introduction-text">Visualize the symmetrical resonance patterns between past and future consciousness states. <span class="info-tooltip" data-tooltip="The Narrative Echo Viewer reveals hidden temporal symmetries in your consciousness field through quantum entanglement visualization.">How does it work?</span></p>
+                <div class="ux-output" id="ux-echo-output">
+                    <h3>UX Test Output: Echo Viewer</h3>
+                    <p class="ux-output-hint">Timeline and tensor controls update this feed.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 
                 <div class="echo-container">
                     <svg class="echo-canvas" viewBox="0 0 1000 200"></svg>
@@ -505,6 +520,11 @@
             
             <div id="results" class="tab-pane">
                 <h2>ASTRA Analysis Results</h2>
+                <div class="ux-output" id="ux-results-output">
+                    <h3>UX Test Output: Results Module</h3>
+                    <p class="ux-output-hint">Result generation status appears here.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <div id="results-container">
                     <p>Submit your birth information to receive your ASTRA analysis.</p>
                     
@@ -533,6 +553,11 @@
             <!-- Fractal Hero's Path χ Tab Content -->
             <div id="fhpx" class="tab-pane">
                 <h2>Fractal Hero's Path χ</h2>
+                <div class="ux-output" id="ux-fhpx-output">
+                    <h3>UX Test Output: Hero's Path</h3>
+                    <p class="ux-output-hint">Journey controls and stage updates appear here.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <div class="hero-journey-container">
                     <div class="section-header">Hero's Journey Archetypal Map</div>
                     <div class="hero-journey-canvas-container">
@@ -605,6 +630,11 @@
             <!-- DreamSigils Module Tab Content -->
             <div id="dreamsigils" class="tab-pane">
                 <h2>DreamSigils Module</h2>
+                <div class="ux-output" id="ux-dreamsigils-output">
+                    <h3>UX Test Output: DreamSigils</h3>
+                    <p class="ux-output-hint">Sigil generation actions update this feed.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <div class="sigil-generator-section">
                     <div class="section-header">Dream Sigil Generator</div>
                     <div class="sigil-canvas-container">
@@ -645,6 +675,11 @@
             <!-- RetroField Feedback Loop Tab Content -->
             <div id="retrofield" class="tab-pane">
                 <h2>RetroField Feedback Loop</h2>
+                <div class="ux-output" id="ux-retrofield-output">
+                    <h3>UX Test Output: RetroField</h3>
+                    <p class="ux-output-hint">Intentions and negotiation controls update this feed.</p>
+                    <ul class="ux-output-list"></ul>
+                </div>
                 <div class="intention-input-section">
                     <div class="section-header">Enter Your Intention</div>
                     <div class="intention-input-container">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1946,6 +1946,152 @@ footer a {
     font-weight: bold !important;
 }
 
+/* UX Text Suite */
+.ux-output {
+    margin: 1.5rem 0;
+    padding: 1rem 1.25rem;
+    background: rgba(6, 10, 24, 0.7);
+    border: 1px solid rgba(138, 43, 226, 0.4);
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+}
+
+.ux-output h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1.05rem;
+    color: #cbb8ff;
+}
+
+.ux-output-hint {
+    margin: 0 0 0.75rem;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.9rem;
+}
+
+.ux-output-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.ux-output-item {
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    background: rgba(22, 28, 50, 0.85);
+    border: 1px solid rgba(0, 150, 255, 0.25);
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.ux-output-item span {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(0, 210, 255, 0.7);
+    margin-bottom: 0.35rem;
+}
+
+.journey-node {
+    padding: 0.5rem 0.75rem;
+    background: rgba(12, 18, 36, 0.8);
+    border: 1px solid rgba(0, 210, 255, 0.3);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.journey-node.active,
+.journey-node:hover {
+    border-color: rgba(255, 62, 157, 0.8);
+    box-shadow: 0 0 12px rgba(255, 62, 157, 0.3);
+    color: #fff;
+}
+
+.node-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.sigil-card {
+    padding: 0.5rem 0.75rem;
+    background: rgba(18, 24, 40, 0.7);
+    border-radius: 8px;
+    border: 1px solid rgba(138, 43, 226, 0.4);
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 0.85rem;
+}
+
+.sigil-animated {
+    animation: sigilSpin 8s linear infinite;
+    transform-origin: 50% 50%;
+    transform-box: fill-box;
+}
+
+@keyframes sigilSpin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.motif-item {
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    background: rgba(16, 22, 38, 0.8);
+    border: 1px solid rgba(0, 210, 255, 0.2);
+    margin-bottom: 0.5rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.probability-path {
+    height: 6px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(0, 210, 255, 0.4), rgba(255, 62, 157, 0.5));
+    margin-bottom: 6px;
+    animation: pathPulse 2.5s ease-in-out infinite;
+}
+
+@keyframes pathPulse {
+    0%,
+    100% {
+        opacity: 0.5;
+        transform: scaleX(1);
+    }
+    50% {
+        opacity: 1;
+        transform: scaleX(1.05);
+    }
+}
+
+.ux-pulse {
+    animation: uxPulse 0.6s ease-out;
+}
+
+@keyframes uxPulse {
+    0% {
+        transform: scale(1);
+        box-shadow: 0 0 0 rgba(0, 214, 255, 0);
+    }
+    50% {
+        transform: scale(1.01);
+        box-shadow: 0 0 18px rgba(0, 214, 255, 0.4);
+    }
+    100% {
+        transform: scale(1);
+        box-shadow: 0 0 0 rgba(0, 214, 255, 0);
+    }
+}
+
 /* Print styles */
 @media print {
     body {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -214,13 +214,13 @@ def test_narrative_basic():
         plt.savefig("output/tests/narrative/events_visualization.png")
         plt.close()
         
-        return True
+        assert True
         
     except Exception as e:
         print(f"Error in narrative basic test: {e}")
         import traceback
         traceback.print_exc()
-        return False
+        raise
 
 def test_narrative_sequence():
     """Test narrative sequence generation for an evolving field"""
@@ -246,7 +246,7 @@ def test_narrative_sequence():
             
             # Create field
             mock_natal = SimpleMockNatal()
-            field = QualiaField(mock_natal, grid_size=(32, 32))
+            field = QualiaField(mock_natal, grid_size=(16, 16))
             
             # Get initial state
             if hasattr(field, 'state'):
@@ -266,8 +266,8 @@ def test_narrative_sequence():
             events_sequence.append(events)
             
             # Evolve for a few steps
-            steps = 3
-            dt = 0.05
+            steps = 1
+            dt = 0.02
             current_state = initial_state.copy()
             
             for step in range(steps):
@@ -280,7 +280,7 @@ def test_narrative_sequence():
                         alpha=0.5,
                         beta=0.9,
                         gamma=0.3,
-                        store_frames=2
+                        store_frames=1
                     )
                     
                     # Get evolved state
@@ -318,7 +318,7 @@ def test_narrative_sequence():
                 print(f"Error saving sequence to JSON: {e}")
             
             # Create visualization of the sequence
-            fig, axes = plt.subplots(2, len(frames), figsize=(len(frames)*4, 8))
+            fig, axes = plt.subplots(2, len(frames), figsize=(len(frames) * 4, 8))
             
             # Get global min/max for consistent colormap
             vmin = min(np.min(f) for f in frames)
@@ -351,8 +351,8 @@ def test_narrative_sequence():
         else:
             # Simplified test - just make sure we can detect events
             # Create a sequence of random fields
-            steps = 3
-            frames = [np.random.random((32, 32)) for _ in range(steps+1)]
+            steps = 2
+            frames = [np.random.random((16, 16)) for _ in range(steps + 1)]
             
             # Define a simple event detector
             def simple_detector(field):
@@ -385,23 +385,19 @@ def test_narrative_sequence():
             plt.savefig("output/tests/narrative/event_counts.png")
             plt.close()
         
-        return True
+        assert True
         
     except Exception as e:
         print(f"Error in narrative sequence test: {e}")
         import traceback
         traceback.print_exc()
-        return False
+        raise
 
 if __name__ == "__main__":
     print(f"Running narrative tests at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     
-    success_basic = test_narrative_basic()
-    success_sequence = test_narrative_sequence()
+    test_narrative_basic()
+    test_narrative_sequence()
     
-    if success_basic and success_sequence:
-        print("NARRATIVE TESTS PASSED")
-        sys.exit(0)
-    else:
-        print("NARRATIVE TESTS FAILED")
-        sys.exit(1)
+    print("NARRATIVE TESTS PASSED")
+    sys.exit(0)


### PR DESCRIPTION
### Motivation
- Surface lightweight, live UX feedback in the documentation UI so each major tab reports short runtime messages for manual QA and visual smoke testing.
- Make narrative-related tests reliable in CI by forcing a headless Matplotlib backend and reducing test runtime and resource use.

### Description
- Added UX output panels to multiple docs tabs (`docs/index.html`) and implemented a small logging API (`logUxUpdate`, `initUxTextSuite`) in `docs/script.js` to emit concise status messages to those panels.
- Wired UX logging into many UI interactions (form inputs, generate button, visualization controls, timeline, topology toggles) and added three self-contained modules in `docs/script.js`: `initHeroPath`, `initDreamSigils`, and `initRetroField` to provide interactive examples and update their UX feeds.
- Added styles for the UX panels and related UI elements in `docs/styles.css` (log item styles, pulse animation, sigil/motif visuals, journey node styles).
- Fixed failing/slow tests by adding `tests/conftest.py` to set `MPLBACKEND=Agg` for headless Matplotlib and updated `tests/test_narrative.py` to raise on failure instead of returning values and to use smaller grids/steps (`QualiaField` grid reduced, fewer evolution steps and frames, reduced random-frame sizes) to speed up execution.

### Testing
- Ran `pytest` and all tests passed: `15 passed, 19 warnings` (test run completed successfully). 
- Verified headless plotting by adding `tests/conftest.py` which sets `MPLBACKEND=Agg`, and confirmed the modified narrative tests complete faster and without requiring a display.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e55e1f1a8832a97506ea26cc90e4f)